### PR TITLE
chore: Add Braintree channel

### DIFF
--- a/transaction.go
+++ b/transaction.go
@@ -17,6 +17,7 @@ type Transaction struct {
 	Type                 string                   `xml:"type,omitempty"`
 	Amount               *Decimal                 `xml:"amount"`
 	CurrencyISOCode      string                   `xml:"currency-iso-code,omitempty"`
+	Channel              string                   `xml:"channel,omitempty"`
 	Tax                  *Decimal                 `xml:"tax-amount"`
 	OrderId              string                   `xml:"order-id,omitempty"`
 	PaymentMethodToken   string                   `xml:"payment-method-token,omitempty"`


### PR DESCRIPTION
This change will allow Braintree to know that this transaction if from ProcessOut, improving their support.