### PR TITLE
chore(POINT-2942): Add Chargeback Details to Dispute Payload

### DIFF
--- a/dispute.go
+++ b/dispute.go
@@ -2,15 +2,18 @@ package braintree
 
 // Dispute object for a *Transaction*
 type Dispute struct {
-	Id              string   `xml:"id"`
-	Amount          *Decimal `xml:"amount"`
-	CurrencyISOCode string   `xml:"currency-iso-code"`
-	AmountWon       *Decimal `xml:"amount-won"`
-	ReceivedDate    Time     `xml:"received-date"`
-	DateWon         Time     `xml:"date-won"`
-	DateOpened      Time     `xml:"date-opened"`
-	Kind            string   `xml:"kind"`
-	Reason          string   `xml:"reason"`
+	Id                string   `xml:"id"`
+	Amount            *Decimal `xml:"amount"`
+	CurrencyISOCode   string   `xml:"currency-iso-code"`
+	AmountWon         *Decimal `xml:"amount-won"`
+	ReceivedDate      Time     `xml:"received-date"`
+	DateWon           Time     `xml:"date-won"`
+	DateOpened        Time     `xml:"date-opened"`
+	Kind              string   `xml:"kind"`
+	Reason            string   `xml:"reason"`
+	ReasonCode        string   `xml:"reason-code"`
+	ReasonDescription string   `xml:"reason-description"`
+	ReplyByDate       string   `xml:"reply-by-date"`
 
 	Transaction *Transaction `xml:"transaction"`
 


### PR DESCRIPTION
## Description

Added the following fields to the Dispute Payload:

```
 <reason-code>%s</reason-code>
 <reason-description>%s</reason-description>
 <reply-by-date>%s</reply-by-date>
 ```

**New structure of Dispute Payload**
```
<dispute>
    .
    .
    <already existing fields>
    .
    .
    .
    <reason-code>%s</reason-code>
    <reason-description>%s</reason-description>
    <reply-by-date>%s</reply-by-date>
</dispute>
```

## Note
This update is needed to implement updates to braintree dispute management on tessel9. See [PR](https://github.com/processout/tessel9/pull/6556)